### PR TITLE
[semver:patch] fixes install_promtool command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,15 @@ For Contributions please read [CONTRIBUTING.md](CONTRIBUTING.md).
 Example: `[semver:major]`
 
 * On Squash and merge. Ensure the semver tag is preserved and entered as a part of the commit message.
+
+## FAQ
+
+### The circleci build fails with the error `The dev version of onemedical/prometheus-tools@dev:alpha has expired.`
+
+To fix this run the following commands:
+```
+circleci orb pack --skip-update-check src > orb.yml
+circleci orb validate orb.yml
+circleci orb publish orb.yml onemedical/prometheus-tools@dev:alpha
+```
+

--- a/src/commands/install_promtool.yml
+++ b/src/commands/install_promtool.yml
@@ -5,7 +5,7 @@ steps:
       command: |
         if ! command -v promtool --version >/dev/null 2>&1  ; then
             echo installing promtool
-            go get github.com/prometheus/prometheus/cmd/promtool
+            go get github.com/prometheus/prometheus/cmd/promtool@master
         else
             echo promtool already exist. skipping install.
         fi


### PR DESCRIPTION
**SEMVER Update Type:**

- [ ] Major
- [ ] Minor
- [x] Patch

## Description:

fixes error during promtool install.
see https://github.com/prometheus/prometheus/issues/8480


## Motivation:

fixes:
```
#!/bin/bash -eo pipefail
go get github.com/prometheus/prometheus/cmd/promtool
# github.com/prometheus/prometheus/cmd/promtool
/go/src/github.com/prometheus/prometheus/cmd/promtool/main.go:642:35: not enough arguments in call to api.LabelValues
	have (context.Context, string, time.Time, time.Time)
	want (context.Context, string, []string, time.Time, time.Time)

Exited with code exit status 2
```
