### PR TITLE
[semver:minor] add ability to specify version of prom/am tool install binaries

### DIFF
--- a/src/commands/install_amtool.yml
+++ b/src/commands/install_amtool.yml
@@ -1,12 +1,16 @@
 description: 'installs amtool'
-
+parameters:
+  version:
+    description: The module version to be installed.
+    type: string
+    default: 'main'
 steps:
   - run:
       name: 'installs amtool'
       command: |
         if ! command -v amtool --version >/dev/null 2>&1  ; then
             echo installing amtool
-            go get github.com/prometheus/alertmanager/cmd/amtool
+            env GO111MODULE=on go get github.com/prometheus/alertmanager/cmd/amtool@<<parameters.version>>
         else
             echo amtool already exist. skipping install.
         fi

--- a/src/commands/install_amtool.yml
+++ b/src/commands/install_amtool.yml
@@ -3,7 +3,7 @@ parameters:
   version:
     description: The module version to be installed.
     type: string
-    default: 'main'
+    default: ${AMTOOL_VERSION:-main}
 steps:
   - run:
       name: 'installs amtool'

--- a/src/commands/install_promtool.yml
+++ b/src/commands/install_promtool.yml
@@ -3,7 +3,7 @@ parameters:
   version:
     description: The module version to be installed.
     type: string
-    default: 'main'
+    default: ${PROMTOOL_VERSION:-main}
 steps:
   - run:
       name: 'installs promtool'

--- a/src/commands/install_promtool.yml
+++ b/src/commands/install_promtool.yml
@@ -1,11 +1,16 @@
 description: 'installs promtool'
+parameters:
+  version:
+    description: The module version to be installed.
+    type: string
+    default: 'main'
 steps:
   - run:
       name: 'installs promtool'
       command: |
         if ! command -v promtool --version >/dev/null 2>&1  ; then
             echo installing promtool
-            env GO111MODULE=on go get github.com/prometheus/prometheus/cmd/promtool@master
+            env GO111MODULE=on go get github.com/prometheus/prometheus/cmd/promtool@<<parameters.version>>
         else
             echo promtool already exist. skipping install.
         fi

--- a/src/executors/golang.yml
+++ b/src/executors/golang.yml
@@ -4,7 +4,7 @@ parameters:
   version:
     description: Go version
     type: string
-    default: '1.15.4'
+    default: '1.17.0'
 
 docker:
   - image: cimg/go:<< parameters.version >>


### PR DESCRIPTION
**SEMVER Update Type:**

- [ ] Major
- [x] Minor
- [ ] Patch

## Description:

Allow for the user of the orb to specify which version of the tool to install.

## Motivation:

Builds failing to install am tools because of dependencies missing.
```
installing amtool
/go/src/github.com/prometheus/alertmanager/notify/notify.go:24:2: cannot find package "github.com/cespare/xxhash" in any of:
	/usr/local/go/src/github.com/cespare/xxhash (from $GOROOT)
	/go/src/github.com/cespare/xxhash (from $GOPATH)
```
This is the cause of breaking changes. Allow for the user of the orb to specify which version of the tool to install. 
see:  prometheus/prometheus#8480


**Closes Issues:**

https://jira.onemedical.com/browse/SRE-529


## Checklist:

- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Usage Example version numbers have been updated.

# CLA Acceptance

Please indicate your acceptance of the [CLA](<../docs/OM Contributor License Agreement_online version_110320.pdf>) below:

- [x] I ACCEPT -- I have sole ownership of intellectual property rights to my Contribution and I am not making a submission in the course of work for my employer.

- [x] I ACCEPT -- I am making the Contribution in the course of my work for my employer, [EMPLOYER NAME]. I have permission from [EMPLOYER NAME] to make the Contribution under the CLA.
