### PR TITLE
 [semver:patch] update deprecated circleci image

### DIFF
--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -1,0 +1,27 @@
+# Commands
+
+Easily add and author [Reusable Commands](https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands) to the `src/commands` directory.
+
+Each _YAML_ file within this directory will be treated as an orb command, with a name which matches its filename.
+
+Example:
+
+```yaml
+description: >
+  Replace this text with a description for this command.
+  # What will this command do?
+  # Descriptions should be short, simple, and clear.
+parameters:
+  greeting:
+    type: string
+    default: "Hello"
+    description: "Select a proper greeting"
+steps:
+  - run:
+      name: Hello World
+      command: echo << parameters.greeting >> world
+```
+
+## See:
+ - [Orb Author Intro](https://circleci.com/docs/2.0/orb-author-intro/#section=configuration)
+ - [How to author commands](https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands)

--- a/src/examples/README.md
+++ b/src/examples/README.md
@@ -1,0 +1,13 @@
+# Usage Examples
+
+Easily author and add [Usage Examples](https://circleci.com/docs/2.0/orb-author/#providing-usage-examples-of-orbs) to the `src/examples` directory.
+
+Each _YAML_ file within this directory will be treated as an orb usage example, with a name which matches its filename.
+
+View the included _[example.yml](./example.yml)_ example.
+
+Usage examples should contain clear use-case based example configurations for using the orb.
+
+
+## See:
+ - [Providing Usage examples](https://circleci.com/docs/2.0/orb-author/#providing-usage-examples-of-orbs)

--- a/src/examples/example.yml
+++ b/src/examples/example.yml
@@ -3,7 +3,7 @@ description: validate and test alerts.
 usage:
   version: 2.1
   orbs:
-    prometheus-tools: onemedical/prometheus-tools@0.1.0
+    prometheus-tools: onemedical/prometheus-tools@0.2.0
   workflows:
     prometheus_rule_deploy:
       jobs:

--- a/src/executors/README.md
+++ b/src/executors/README.md
@@ -1,0 +1,28 @@
+# Executors
+
+Easily author and add [Parameterized Executors](https://circleci.com/docs/2.0/reusing-config/#executors) to the `src/executors` directory.
+
+Each _YAML_ file within this directory will be treated as an orb executor, with a name which matches its filename.
+
+Executors can be used to parameterize the same environment across many jobs. Orbs nor jobs _require_ executors, but may be helpful in some cases, such as: [parameterizing the Node version for a testing job so that matrix testing may be used](https://circleci.com/orbs/registry/orb/circleci/node#usage-run_matrix_testing).
+
+Example:
+
+```yaml
+description: >
+  This is a sample executor using Docker and Node.
+docker:
+  - image: 'cimg/node:<<parameters.tag>>'
+parameters:
+  tag:
+    default: lts
+    description: >
+      Pick a specific circleci/node image variant:
+      https://hub.docker.com/r/cimg/node/tags
+    type: string
+```
+
+## See:
+ - [Orb Author Intro](https://circleci.com/docs/2.0/orb-author-intro/#section=configuration)
+ - [How To Author Executors](https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors)
+ - [Node Orb Executor](https://github.com/CircleCI-Public/node-orb/blob/master/src/executors/default.yml)

--- a/src/jobs/README.md
+++ b/src/jobs/README.md
@@ -1,0 +1,31 @@
+# Jobs
+
+Easily author and add [Parameterized Jobs](https://circleci.com/docs/2.0/reusing-config/#authoring-parameterized-jobs) to the `src/jobs` directory.
+
+Each _YAML_ file within this directory will be treated as an orb job, with a name which matches its filename.
+
+Jobs may invoke orb commands and other steps to fully automate tasks with minimal user configuration.
+
+Example:
+
+
+```yaml
+description: >
+  # What will this job do?
+  # Descriptions should be short, simple, and clear.
+  Sample description
+executor: default
+parameters:
+  greeting:
+    type: string
+    default: "Hello"
+    description: "Select a proper greeting"
+steps:
+  - greet:
+      greeting: << parameters.greeting >>
+```
+
+## See:
+ - [Orb Author Intro](https://circleci.com/docs/2.0/orb-author-intro/#section=configuration)
+ - [How To Author Commands](https://circleci.com/docs/2.0/reusing-config/#authoring-parameterized-jobs)
+ - [Node Orb "test" Job](https://github.com/CircleCI-Public/node-orb/blob/master/src/jobs/test.yml)

--- a/src/jobs/verify_rules.yml
+++ b/src/jobs/verify_rules.yml
@@ -11,7 +11,7 @@ parameters:
     type: string
     default: '.'
 docker:
-  - image: circleci/golang:1.15
+  - image: cimg/go:1.18
 steps:
   - check_rules:
       rule_files: <<parameters.rule_files>>


### PR DESCRIPTION
**SEMVER Update Type:**

- [ ] Major
- [ ] Minor
- [x] Patch

## Description:

update deprecated circleci image

<img width="1191" alt="image" src="https://user-images.githubusercontent.com/1307417/160161387-80f30bcc-27b6-4ad1-bae8-b90014a59a23.png">


## Motivation:

maintenance


## Checklist:

- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Usage Example version numbers have been updated.

# CLA Acceptance

Please indicate your acceptance of the [CLA](<../docs/OM Contributor License Agreement_online version_110320.pdf>) below:

- [x] I ACCEPT -- I have sole ownership of intellectual property rights to my Contribution and I am not making a submission in the course of work for my employer.

- [x] I ACCEPT -- I am making the Contribution in the course of my work for my employer, [EMPLOYER NAME]. I have permission from [EMPLOYER NAME] to make the Contribution under the CLA.
